### PR TITLE
Improvements

### DIFF
--- a/src/Models/NugetSession.cs
+++ b/src/Models/NugetSession.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using Community.VisualStudio.Toolkit;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.Shell;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using Settings = NuGet.Configuration.Settings;
@@ -10,20 +11,37 @@ namespace NuGetMonitor.Models
     internal sealed class NuGetSession : IDisposable
     {
         private readonly CancellationTokenSource _cancellationTokenSource = new();
-        private readonly TaskCompletionSource<ICollection<SourceRepository>> _sourceRepositories = new();
 
         public NuGetSession()
         {
-            Load();
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var solution = VS.Solutions.GetCurrentSolution();
+            var solutionDirectory = Path.GetDirectoryName(solution?.FullPath);
+
+            var settings = Settings.LoadDefaultSettings(solutionDirectory);
+
+            GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+
+            var packageSourceProvider = new PackageSourceProvider(settings);
+            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, Repository.Provider.GetCoreV3());
+            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
+
+            SourceRepositories = sourceRepositories.ToArray();
+            PackageDownloadContext = new PackageDownloadContext(SourceCacheContext);
         }
 
         public MemoryCache Cache { get; } = new(new MemoryCacheOptions { });
 
         public SourceCacheContext SourceCacheContext { get; } = new();
 
+        public PackageDownloadContext PackageDownloadContext { get; }
+
         public CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
-        public Task<ICollection<SourceRepository>> GetSourceRepositories() => _sourceRepositories.Task;
+        public ICollection<SourceRepository> SourceRepositories { get; }
+
+        public string GlobalPackagesFolder { get; private set; }
 
         public void ThrowIfCancellationRequested() => CancellationToken.ThrowIfCancellationRequested();
 
@@ -33,18 +51,6 @@ namespace NuGetMonitor.Models
             _cancellationTokenSource.Dispose();
             SourceCacheContext.Dispose();
             Cache.Dispose();
-        }
-
-        private async void Load()
-        {
-            var solution = await VS.Solutions.GetCurrentSolutionAsync();
-            var solutionDirectory = Path.GetDirectoryName(solution?.FullPath);
-
-            var packageSourceProvider = new PackageSourceProvider(Settings.LoadDefaultSettings(solutionDirectory));
-            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, Repository.Provider.GetCoreV3());
-            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
-
-            _sourceRepositories.SetResult(sourceRepositories.ToArray());
         }
     }
 }

--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -4,13 +4,13 @@ using System.Runtime.InteropServices;
 
 namespace NuGetMonitor.Options;
 
-internal partial class OptionsProvider
+internal sealed class OptionsProvider
 {
     [ComVisible(true)]
     public class GeneralOptions : BaseOptionPage<General> { }
 }
 
-public class General : BaseOptionModel<General>
+public sealed class General : BaseOptionModel<General>
 {
     [Category("Notifications")]
     [DisplayName("Show transitive packages issues")]

--- a/src/Services/NuGetService.cs
+++ b/src/Services/NuGetService.cs
@@ -84,11 +84,6 @@ internal static class NuGetService
             var project = projectPackageReferences.Key;
 
             var projectsInTargetFramework = project.GetProjectsInTargetFramework();
-            if (projectsInTargetFramework is null)
-            {
-                await LoggingService.LogAsync($"No target framework found in project {Path.GetFileName(project.FullPath)} (old project format?) - skipping transitive package analysis.");
-                continue;
-            }
 
             var topLevelPackagesInProject = topLevelPackages
                 .Where(package => projectPackageReferences.Any(item => package.PackageReferenceEntries.Contains(item)))


### PR DESCRIPTION
- Performance: Avoid downloading every package, use global package folder.
- Support multi-targeting projects with conditional package references.
- Fix #15: Use `DependencyInfoResource` instead of `FindPackageByIdResource` to be able to filter unlisted versions