### PR TITLE
Fix #44: Revert transitive fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Community.VisualStudio.Toolkit.17" Version="17.0.522" />
     <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" />
     <PackageVersion Include="DataGridExtensions" Version="2.6.0" />
-    <PackageVersion Include="Fody" Version="6.8.1" />
+    <PackageVersion Include="Fody" Version="6.8.2" />
     <PackageVersion Include="Microsoft.Build" Version="[17.4.0]" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="[17.4.0]" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
@@ -19,10 +19,5 @@
     <PackageVersion Include="TomsToolbox.Essentials" Version="2.18.1" />
     <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.18.1" />
     <PackageVersion Include="VSIX-SdkProjectAdapter" Version="3.0.0" />
-  </ItemGroup>
-  <ItemGroup Label="Transitive fixes">
-    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
-    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/NuGetMonitor.sln
+++ b/NuGetMonitor.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 		src\publish-manifest.json = src\publish-manifest.json
 		README.md = README.md
 		.github\workflows\workflow.yml = .github\workflows\workflow.yml


### PR DESCRIPTION
leads to hidden crashes in older VS versions since we depend on the assemblies delivered with VS.