### PR TITLE
Fixes

### DIFF
--- a/src/NuGetMonitor.Model/ExtensionMethods.cs
+++ b/src/NuGetMonitor.Model/ExtensionMethods.cs
@@ -36,4 +36,9 @@ public static class ExtensionMethods
     {
         return projectItem.GetMetadataValue("Justification");
     }
+
+    public static bool IsGlobalPackageReference(this ProjectItem projectItem)
+    {
+        return projectItem.ItemType.Equals("GlobalPackageReference", StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/NuGetMonitor.Model/Services/ProjectService.cs
+++ b/src/NuGetMonitor.Model/Services/ProjectService.cs
@@ -248,6 +248,9 @@ public static class ProjectService
 
     internal static bool GetIsPrivateAsset(this ProjectItem projectItem)
     {
+        if (projectItem.IsGlobalPackageReference())
+            return true;
+
         var value = projectItem.GetMetadata("PrivateAssets")?.EvaluatedValue;
 
         return string.Equals(value, "all", StringComparison.OrdinalIgnoreCase);

--- a/src/NuGetMonitor/View/Monitor/NugetMonitorViewModel.cs
+++ b/src/NuGetMonitor/View/Monitor/NugetMonitorViewModel.cs
@@ -233,6 +233,10 @@ internal sealed partial class NuGetMonitorViewModel : INotifyPropertyChanged
             if (packageDetails == null)
                 continue;
 
+            // e.g. Analyzer packages do not specify any target framework, they are just compatible with everything
+            if (packageDetails.SupportedFrameworks.Count == 0)
+                continue;
+
             var projects = viewModel.Items
                 .Where(referenceEntry => referenceEntry.VersionKind != VersionKind.CentralDefinition && referenceEntry.Identity.Id == packageReference.Id && referenceEntry.Identity.VersionRange.Equals(packageReference.VersionRange))
                 .Select(referenceEntry => referenceEntry.ProjectItemInTargetFramework.Project)

--- a/src/NuGetMonitor/View/Monitor/NugetMonitorViewModel.cs
+++ b/src/NuGetMonitor/View/Monitor/NugetMonitorViewModel.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGetMonitor.Abstractions;
+using NuGetMonitor.Model;
 using NuGetMonitor.Model.Models;
 using NuGetMonitor.Model.Services;
 using NuGetMonitor.Services;
@@ -238,7 +239,7 @@ internal sealed partial class NuGetMonitorViewModel : INotifyPropertyChanged
                 continue;
 
             var projects = viewModel.Items
-                .Where(referenceEntry => referenceEntry.VersionKind != VersionKind.CentralDefinition && referenceEntry.Identity.Id == packageReference.Id && referenceEntry.Identity.VersionRange.Equals(packageReference.VersionRange))
+                .Where(referenceEntry => referenceEntry.VersionKind is not VersionKind.CentralDefinition && !referenceEntry.VersionSource.IsGlobalPackageReference() && referenceEntry.Identity.Id == packageReference.Id && referenceEntry.Identity.VersionRange.Equals(packageReference.VersionRange))
                 .Select(referenceEntry => referenceEntry.ProjectItemInTargetFramework.Project)
                 .Distinct();
 


### PR DESCRIPTION
- Omit warning about package compatibility for analyzer packages.
- Treat GlobalPackageReference entries as private assets.